### PR TITLE
Adds support for emoji font

### DIFF
--- a/fonts.css
+++ b/fonts.css
@@ -6,6 +6,11 @@
 /* standard "serif" font family */
 
 @font-face {
+    font-family: serif; /* last resort for adding emoji support */
+    src: prince-lookup("NotoColorEmoji")
+}
+
+@font-face {
     font-family: serif; /* last resort font */
     src: prince-lookup("Arial")
 }


### PR DESCRIPTION
PDF's with emoji's were receiving errors due to prince XML not being able to find a font which supports them. 
For example - 

```
prince: page 1: warning: no font for Miscellaneous Symbols and Pictographs character U+1F3D6, fallback to U+2BD1 ⯑
prince: page 1: warning: Ensure fonts are available on the system or load them via a @font-face rule.
prince: page 1: warning: For more information see:
prince: page 1: warning: https://www.princexml.com/doc/help-install/#missing-glyphs-or-fonts
prince: internal error: Unable to find any available fonts.
```

After adding this font, prince is able to process PDF's with coloured emoji's. 